### PR TITLE
Add CLI options for ID type, data records, pending, and negative response

### DIFF
--- a/src/mock.py
+++ b/src/mock.py
@@ -34,24 +34,24 @@ def get_argparser():
         help="enable verbose output"
     )
     parser.add_argument(
-        "--id-type",
+        "-i", "--id-type",
         choices=["11func", "11phys", "29bits"],
         default="29bits",
         help="CAN ID type: 11bits functional (11func), 11bits physical (11phys), or 29bits (default: 29bits)"
     )
     parser.add_argument(
-        "--data",
+        "-d", "--data",
         choices=["zeros", "step", "random"],
         default="zeros",
         help="data record values: zeros, step, or random pseudorandom (default: zeros)"
     )
     parser.add_argument(
-        "--pending",
+        "-p", "--pending",
         action="store_true",
         help="enable pending response before positive/negative response"
     )
     parser.add_argument(
-        "--negative",
+        "-n", "--negative",
         action="store_true",
         help="enable negative response instead of positive response"
     )

--- a/src/mock.py
+++ b/src/mock.py
@@ -9,6 +9,7 @@ License:
 """
 
 import argparse
+import random
 import time
 import can
 import isotp
@@ -28,9 +29,31 @@ def get_argparser():
         help="device name like COM9 or /dev/ttyACM0 (required)"
     )
     parser.add_argument(
-        "-v", "--verbose",    # TODO
+        "-v", "--verbose",
         action="store_true",
         help="enable verbose output"
+    )
+    parser.add_argument(
+        "--id-type",
+        choices=["11func", "11phys", "29bits"],
+        default="29bits",
+        help="CAN ID type: 11bits functional (11func), 11bits physical (11phys), or 29bits (default: 29bits)"
+    )
+    parser.add_argument(
+        "--data",
+        choices=["zeros", "step", "random"],
+        default="zeros",
+        help="data record values: zeros, step, or random pseudorandom (default: zeros)"
+    )
+    parser.add_argument(
+        "--pending",
+        action="store_true",
+        help="enable pending response before positive/negative response"
+    )
+    parser.add_argument(
+        "--negative",
+        action="store_true",
+        help="enable negative response instead of positive response"
     )
     return parser
 
@@ -115,23 +138,30 @@ def main():
     else:
         notifier = can.Notifier(bus, [])
 
-    # TODO: ID type (11bits func. / 11bits phys. / 29bits)
-    # rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x700, rxid=0x7DF)    # func
-    # tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7FF, rxid=0x7F7)    # func
-    # rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)    # phys
-    # tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)    # phys
-    rx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0xFF)
-    tx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0x77)
+    if args.id_type == "11func":
+        rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x700, rxid=0x7DF)
+        tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7FF, rxid=0x7F7)
+    elif args.id_type == "11phys":
+        rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)
+        tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)
+    else:  # 29bits (default)
+        rx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0xFF)
+        tx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0x77)
 
     # Network/Transport layer (IsoTP protocol). Register a new listener
     rx_stack = isotp.NotifierBasedCanStack(bus=bus, notifier=notifier, address=rx_addr, params=isotp_params)
     tx_stack = isotp.NotifierBasedCanStack(bus=bus, notifier=notifier, address=tx_addr, params=isotp_params)
 
+    # Fixed-seed RNG so random data is reproducible and differs per DID
+    rng = random.Random(42)
     data_records = {}
     for i in range(0xfa13, 0xfa16):
-        # TODO: data record for DID (zeros / step / random?)
-        data_records[i] = b''.join(bytes([j % 256]) for j in range(772))
-        # data_records[i] = bytearray([i - 0xfa12] * 772)
+        if args.data == "zeros":
+            data_records[i] = bytes(772)
+        elif args.data == "step":
+            data_records[i] = b''.join(bytes([j % 256]) for j in range(772))
+        else:  # random
+            data_records[i] = bytes(rng.getrandbits(8) for _ in range(772))
 
     requests = {}
     responses = {}
@@ -150,13 +180,11 @@ def main():
             for i in range(0xfa13, 0xfa16):
                 if payload is not None:
                     if payload == requests[i].get_payload():
-                        # TODO: pending (on / off)
-                        if False:   # Pending
+                        if args.pending:
                             tx_stack.send(pend_response.get_payload())
                             time.sleep(3)
 
-                        # TODO: negative response (on / off)
-                        if False:   # Nega
+                        if args.negative:
                             tx_stack.send(nega_response.get_payload())
 
                         else:


### PR DESCRIPTION
Implements the remaining CLI options from #2:

- `--id-type`: select 11bits functional, 11bits physical, or 29bits (default)
- `--data`: set data record values to zeros (default), step, or random (fixed-seed pseudorandom, differs per DID)
- `--pending`: enable pending response before main response
- `--negative`: enable negative response instead of positive response

Closes #2

Generated with [Claude Code](https://claude.ai/code)