### PR TITLE
Add -b/--bg-frames CLI option to send background CAN frames

### DIFF
--- a/src/mock.py
+++ b/src/mock.py
@@ -9,11 +9,15 @@ License:
 """
 
 import argparse
+import random
+import threading
 import time
 import can
 import isotp
 from udsoncan import Request, Response
 from udsoncan.services import ReadDataByIdentifier
+
+_BG_FRAMES_RNG_SEED = 42
 
 
 def get_argparser():
@@ -32,7 +36,57 @@ def get_argparser():
         action="store_true",
         help="enable verbose output"
     )
+    parser.add_argument(
+        "-b", "--bg-frames",
+        type=int,
+        default=0,
+        metavar="N",
+        help="number of background CAN IDs to send at 100ms cycle (0-500, default 0)"
+    )
     return parser
+
+
+def generate_background_frames(count):
+    """Return a list of (arbitration_id, is_extended_id, data) for background frames.
+
+    Half of the IDs are standard 11-bit, the other half extended 29-bit.
+    IDs and data are pseudorandom with a fixed seed for reproducibility.
+    """
+    rng = random.Random(_BG_FRAMES_RNG_SEED)
+
+    n_std = count // 2
+    n_ext = count - n_std
+
+    frames = []
+    for _ in range(n_std):
+        arb_id = rng.randint(0, 0x7FF)
+        data = bytes(rng.randint(0, 255) for _ in range(8))
+        frames.append((arb_id, False, data))
+
+    for _ in range(n_ext):
+        arb_id = rng.randint(0, 0x1FFFFFFF)
+        data = bytes(rng.randint(0, 255) for _ in range(8))
+        frames.append((arb_id, True, data))
+
+    return frames
+
+
+def background_sender(bus, frames, stop_event):
+    """Send all background CAN frames, repeating every 100ms until stop_event is set."""
+    while not stop_event.is_set():
+        cycle_start = time.monotonic()
+        for arb_id, is_extended, data in frames:
+            if stop_event.is_set():
+                return
+            msg = can.Message(arbitration_id=arb_id, is_extended_id=is_extended, data=data)
+            try:
+                bus.send(msg)
+            except can.CanError:
+                pass
+        elapsed = time.monotonic() - cycle_start
+        remaining = 0.1 - elapsed
+        if remaining > 0:
+            stop_event.wait(remaining)
 
 
 def main():
@@ -41,6 +95,9 @@ def main():
     # Parse command line arguments
     argparser = get_argparser()
     args = argparser.parse_args()
+
+    if not 0 <= args.bg_frames <= 500:
+        argparser.error("--bg-frames must be between 0 and 500")
 
     # Setup and start a CAN bus
     try:
@@ -144,6 +201,16 @@ def main():
     rx_stack.start()
     tx_stack.start()
 
+    stop_event = threading.Event()
+    if args.bg_frames > 0:
+        frames = generate_background_frames(args.bg_frames)
+        bg_thread = threading.Thread(
+            target=background_sender,
+            args=(bus, frames, stop_event),
+            daemon=True,
+        )
+        bg_thread.start()
+
     try:
         while True:
             payload = rx_stack.recv(block=True, timeout=0.01)
@@ -164,6 +231,8 @@ def main():
 
     except Exception as err:
         print(err)
+
+    stop_event.set()
 
     rx_stack.stop()
     tx_stack.stop()

--- a/src/mock.py
+++ b/src/mock.py
@@ -19,6 +19,7 @@ from udsoncan import Request, Response
 from udsoncan.services import ReadDataByIdentifier
 
 _BG_FRAMES_RNG_SEED = 42
+_BG_FRAMES_CYCLE_TIME_MS = 100
 
 
 def get_argparser():
@@ -43,13 +44,6 @@ def get_argparser():
         default=0,
         metavar="N",
         help="number of background CAN IDs to send (0-500, default 0)"
-    )
-    parser.add_argument(
-        "-c", "--cycle-time",
-        type=int,
-        default=100,
-        metavar="MS",
-        help="background frame cycle time in milliseconds (1-10000, default 100)"
     )
     parser.add_argument(
         "-i", "--id-type",
@@ -128,8 +122,6 @@ def main():
 
     if not 0 <= args.bg_frames <= 500:
         argparser.error("--bg-frames must be between 0 and 500")
-    if not 1 <= args.cycle_time <= 10000:
-        argparser.error("--cycle-time must be between 1 and 10000")
 
     # Setup and start a CAN bus
     try:
@@ -245,7 +237,7 @@ def main():
         frames = generate_background_frames(args.bg_frames)
         bg_thread = threading.Thread(
             target=background_sender,
-            args=(bus, frames, stop_event, args.cycle_time / 1000),
+            args=(bus, frames, stop_event, _BG_FRAMES_CYCLE_TIME_MS / 1000),
             daemon=True,
         )
         bg_thread.start()

--- a/src/mock.py
+++ b/src/mock.py
@@ -8,10 +8,11 @@ License:
     See the accompanying LICENSE file for full terms.
 """
 
-import argparse
 import random
 import threading
 import time
+
+import argparse
 import can
 import isotp
 from udsoncan import Request, Response

--- a/src/mock.py
+++ b/src/mock.py
@@ -18,48 +18,6 @@ import isotp
 from udsoncan import Response
 from udsoncan.services import ReadDataByIdentifier
 
-_BG_FRAMES_RNG_SEED = 42
-_BG_FRAMES_CYCLE_TIME_MS = 100
-
-_ISOTP_PARAMS = {
-    # Will request the sender to wait 0ms between consecutive frame.
-    # 0-127ms or 100-900ns with values from 0xF1-0xF9.
-    'stmin': 0,
-    # Request the sender to send all consecutives frames
-    # without waiting a new flow control message.
-    'blocksize': 0,
-    # Number of wait frame allowed before triggering an error.
-    'wftmax': 0,
-    # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
-    'tx_data_length': 8,
-    # Minimum length of CAN messages. Messages are padded to meet this length.
-    'tx_data_min_length': 8,
-    # Will pad all transmitted CAN messages with byte 0x00.
-    'tx_padding': 0,
-    # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
-    'rx_flowcontrol_timeout': 1000,
-    # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
-    'rx_consecutive_frame_timeout': 1000,
-    # When sending, respect the stmin requirement of the receiver.
-    # Could be set to a float value in seconds.
-    'override_receiver_stmin': None,
-    # Limit the size of receive frame.
-    'max_frame_size': 4095,
-    # Does not set the can_fd flag on the output CAN messages.
-    'can_fd': False,
-    # Does not set the bitrate_switch flag on the output CAN messages.
-    'bitrate_switch': False,
-    # Disable the rate limiter.
-    'rate_limit_enable': False,
-    # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
-    'rate_limit_max_bitrate': 1000000,
-    # Ignored when rate_limit_enable=False.
-    # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
-    'rate_limit_window_size': 0.2,
-    # Does not use the listen_mode which prevent transmission.
-    'listen_mode': False,
-}
-
 
 def get_argparser():
     """Get the command line argument parser."""
@@ -110,6 +68,49 @@ def get_argparser():
         help="enable negative response instead of positive response"
     )
     return parser
+
+
+_BG_FRAMES_RNG_SEED = 42
+_BG_FRAMES_CYCLE_TIME_MS = 100
+
+_ISOTP_PARAMS = {
+    # Will request the sender to wait 0ms between consecutive frame.
+    # 0-127ms or 100-900ns with values from 0xF1-0xF9.
+    'stmin': 0,
+    # Request the sender to send all consecutives frames
+    # without waiting a new flow control message.
+    'blocksize': 0,
+    # Number of wait frame allowed before triggering an error.
+    'wftmax': 0,
+    # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
+    'tx_data_length': 8,
+    # Minimum length of CAN messages. Messages are padded to meet this length.
+    'tx_data_min_length': 8,
+    # Will pad all transmitted CAN messages with byte 0x00.
+    'tx_padding': 0,
+    # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
+    'rx_flowcontrol_timeout': 1000,
+    # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
+    'rx_consecutive_frame_timeout': 1000,
+    # When sending, respect the stmin requirement of the receiver.
+    # Could be set to a float value in seconds.
+    'override_receiver_stmin': None,
+    # Limit the size of receive frame.
+    'max_frame_size': 4095,
+    # Does not set the can_fd flag on the output CAN messages.
+    'can_fd': False,
+    # Does not set the bitrate_switch flag on the output CAN messages.
+    'bitrate_switch': False,
+    # Disable the rate limiter.
+    'rate_limit_enable': False,
+    # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
+    'rate_limit_max_bitrate': 1000000,
+    # Ignored when rate_limit_enable=False.
+    # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
+    'rate_limit_window_size': 0.2,
+    # Does not use the listen_mode which prevent transmission.
+    'listen_mode': False,
+}
 
 
 def generate_background_frames(count):

--- a/src/mock.py
+++ b/src/mock.py
@@ -42,7 +42,14 @@ def get_argparser():
         type=int,
         default=0,
         metavar="N",
-        help="number of background CAN IDs to send at 100ms cycle (0-500, default 0)"
+        help="number of background CAN IDs to send (0-500, default 0)"
+    )
+    parser.add_argument(
+        "-c", "--cycle-time",
+        type=int,
+        default=100,
+        metavar="MS",
+        help="background frame cycle time in milliseconds (1-10000, default 100)"
     )
     parser.add_argument(
         "-i", "--id-type",
@@ -94,8 +101,8 @@ def generate_background_frames(count):
     return frames
 
 
-def background_sender(bus, frames, stop_event):
-    """Send all background CAN frames, repeating every 100ms until stop_event is set."""
+def background_sender(bus, frames, stop_event, cycle_time_s):
+    """Send all background CAN frames, repeating every cycle_time_s seconds until stop_event is set."""
     while not stop_event.is_set():
         cycle_start = time.monotonic()
         for arb_id, is_extended, data in frames:
@@ -107,7 +114,7 @@ def background_sender(bus, frames, stop_event):
             except can.CanError:
                 pass
         elapsed = time.monotonic() - cycle_start
-        remaining = 0.1 - elapsed
+        remaining = cycle_time_s - elapsed
         if remaining > 0:
             stop_event.wait(remaining)
 
@@ -121,6 +128,8 @@ def main():
 
     if not 0 <= args.bg_frames <= 500:
         argparser.error("--bg-frames must be between 0 and 500")
+    if not 1 <= args.cycle_time <= 10000:
+        argparser.error("--cycle-time must be between 1 and 10000")
 
     # Setup and start a CAN bus
     try:
@@ -236,7 +245,7 @@ def main():
         frames = generate_background_frames(args.bg_frames)
         bg_thread = threading.Thread(
             target=background_sender,
-            args=(bus, frames, stop_event),
+            args=(bus, frames, stop_event, args.cycle_time / 1000),
             daemon=True,
         )
         bg_thread.start()

--- a/src/mock.py
+++ b/src/mock.py
@@ -18,6 +18,48 @@ import isotp
 from udsoncan import Response
 from udsoncan.services import ReadDataByIdentifier
 
+_BG_FRAMES_RNG_SEED = 42
+_BG_FRAMES_CYCLE_TIME_MS = 100
+
+_ISOTP_PARAMS = {
+    # Will request the sender to wait 0ms between consecutive frame.
+    # 0-127ms or 100-900ns with values from 0xF1-0xF9.
+    'stmin': 0,
+    # Request the sender to send all consecutives frames
+    # without waiting a new flow control message.
+    'blocksize': 0,
+    # Number of wait frame allowed before triggering an error.
+    'wftmax': 0,
+    # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
+    'tx_data_length': 8,
+    # Minimum length of CAN messages. Messages are padded to meet this length.
+    'tx_data_min_length': 8,
+    # Will pad all transmitted CAN messages with byte 0x00.
+    'tx_padding': 0,
+    # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
+    'rx_flowcontrol_timeout': 1000,
+    # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
+    'rx_consecutive_frame_timeout': 1000,
+    # When sending, respect the stmin requirement of the receiver.
+    # Could be set to a float value in seconds.
+    'override_receiver_stmin': None,
+    # Limit the size of receive frame.
+    'max_frame_size': 4095,
+    # Does not set the can_fd flag on the output CAN messages.
+    'can_fd': False,
+    # Does not set the bitrate_switch flag on the output CAN messages.
+    'bitrate_switch': False,
+    # Disable the rate limiter.
+    'rate_limit_enable': False,
+    # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
+    'rate_limit_max_bitrate': 1000000,
+    # Ignored when rate_limit_enable=False.
+    # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
+    'rate_limit_window_size': 0.2,
+    # Does not use the listen_mode which prevent transmission.
+    'listen_mode': False,
+}
+
 
 def get_argparser():
     """Get the command line argument parser."""
@@ -68,49 +110,6 @@ def get_argparser():
         help="enable negative response instead of positive response"
     )
     return parser
-
-
-_BG_FRAMES_RNG_SEED = 42
-_BG_FRAMES_CYCLE_TIME_MS = 100
-
-_ISOTP_PARAMS = {
-    # Will request the sender to wait 0ms between consecutive frame.
-    # 0-127ms or 100-900ns with values from 0xF1-0xF9.
-    'stmin': 0,
-    # Request the sender to send all consecutives frames
-    # without waiting a new flow control message.
-    'blocksize': 0,
-    # Number of wait frame allowed before triggering an error.
-    'wftmax': 0,
-    # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
-    'tx_data_length': 8,
-    # Minimum length of CAN messages. Messages are padded to meet this length.
-    'tx_data_min_length': 8,
-    # Will pad all transmitted CAN messages with byte 0x00.
-    'tx_padding': 0,
-    # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
-    'rx_flowcontrol_timeout': 1000,
-    # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
-    'rx_consecutive_frame_timeout': 1000,
-    # When sending, respect the stmin requirement of the receiver.
-    # Could be set to a float value in seconds.
-    'override_receiver_stmin': None,
-    # Limit the size of receive frame.
-    'max_frame_size': 4095,
-    # Does not set the can_fd flag on the output CAN messages.
-    'can_fd': False,
-    # Does not set the bitrate_switch flag on the output CAN messages.
-    'bitrate_switch': False,
-    # Disable the rate limiter.
-    'rate_limit_enable': False,
-    # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
-    'rate_limit_max_bitrate': 1000000,
-    # Ignored when rate_limit_enable=False.
-    # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
-    'rate_limit_window_size': 0.2,
-    # Does not use the listen_mode which prevent transmission.
-    'listen_mode': False,
-}
 
 
 def generate_background_frames(count):

--- a/src/mock.py
+++ b/src/mock.py
@@ -15,11 +15,50 @@ import time
 import argparse
 import can
 import isotp
-from udsoncan import Request, Response
+from udsoncan import Response
 from udsoncan.services import ReadDataByIdentifier
 
 _BG_FRAMES_RNG_SEED = 42
 _BG_FRAMES_CYCLE_TIME_MS = 100
+
+_ISOTP_PARAMS = {
+    # Will request the sender to wait 0ms between consecutive frame.
+    # 0-127ms or 100-900ns with values from 0xF1-0xF9.
+    'stmin': 0,
+    # Request the sender to send all consecutives frames
+    # without waiting a new flow control message.
+    'blocksize': 0,
+    # Number of wait frame allowed before triggering an error.
+    'wftmax': 0,
+    # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
+    'tx_data_length': 8,
+    # Minimum length of CAN messages. Messages are padded to meet this length.
+    'tx_data_min_length': 8,
+    # Will pad all transmitted CAN messages with byte 0x00.
+    'tx_padding': 0,
+    # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
+    'rx_flowcontrol_timeout': 1000,
+    # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
+    'rx_consecutive_frame_timeout': 1000,
+    # When sending, respect the stmin requirement of the receiver.
+    # Could be set to a float value in seconds.
+    'override_receiver_stmin': None,
+    # Limit the size of receive frame.
+    'max_frame_size': 4095,
+    # Does not set the can_fd flag on the output CAN messages.
+    'can_fd': False,
+    # Does not set the bitrate_switch flag on the output CAN messages.
+    'bitrate_switch': False,
+    # Disable the rate limiter.
+    'rate_limit_enable': False,
+    # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
+    'rate_limit_max_bitrate': 1000000,
+    # Ignored when rate_limit_enable=False.
+    # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
+    'rate_limit_window_size': 0.2,
+    # Does not use the listen_mode which prevent transmission.
+    'listen_mode': False,
+}
 
 
 def get_argparser():
@@ -49,7 +88,10 @@ def get_argparser():
         "-i", "--id-type",
         choices=["11func", "11phys", "29bits"],
         default="29bits",
-        help="CAN ID type: 11bits functional (11func), 11bits physical (11phys), or 29bits (default: 29bits)"
+        help=(
+            "CAN ID type: 11bits functional (11func), 11bits physical (11phys),"
+            " or 29bits (default: 29bits)"
+        )
     )
     parser.add_argument(
         "-d", "--data",
@@ -96,7 +138,7 @@ def generate_background_frames(count):
 
 
 def background_sender(bus, frames, stop_event, cycle_time_s):
-    """Send all background CAN frames, repeating every cycle_time_s seconds until stop_event is set."""
+    """Send background CAN frames repeatedly every cycle_time_s seconds."""
     while not stop_event.is_set():
         cycle_start = time.monotonic()
         for arb_id, is_extended, data in frames:
@@ -113,24 +155,14 @@ def background_sender(bus, frames, stop_event, cycle_time_s):
             stop_event.wait(remaining)
 
 
-def main():
-    """Main process."""
-
-    # Parse command line arguments
-    argparser = get_argparser()
-    args = argparser.parse_args()
-
-    if not 0 <= args.bg_frames <= 500:
-        argparser.error("--bg-frames must be between 0 and 500")
-
-    # Setup and start a CAN bus
+def _create_bus(args):
+    """Create and return a CAN bus, or None if initialization fails."""
     try:
         if args.devicename == "virtual":
-            bus = can.Bus('test', interface='virtual')
-        elif args.devicename == "vector":
-            bus = can.Bus(interface='vector', channel=0, bitrate=500000, app_name="Python-CAN")
-        else:
-            bus = can.Bus(interface='slcan', channel=args.devicename, bitrate=500000)
+            return can.Bus('test', interface='virtual')
+        if args.devicename == "vector":
+            return can.Bus(interface='vector', channel=0, bitrate=500000, app_name="Python-CAN")
+        return can.Bus(interface='slcan', channel=args.devicename, bitrate=500000)
     except can.CanInitializationError as err:
         print("Could not access CAN network.")
         print("The program is aborting.")
@@ -141,61 +173,21 @@ def main():
             print( "  - Device not powered: check the device is powered on")
             print( "  - Device not connected: check the device is properly connected")
             print( "  - Wrong firmware: check the device has correct firmware")
-            print( "  - Permission denied (Linux): try 'sudo usermod -aG dialout $USER' and re-login")
+            print(
+                "  - Permission denied (Linux): try 'sudo usermod -aG dialout $USER'"
+                " and re-login"
+            )
             print(f"    or 'sudo chmod 666 {args.devicename}'")
-        return
-    except Exception as err:
+        return None
+    except Exception as err:  # pylint: disable=broad-exception-caught
         print("Could not access CAN network.")
         print("The program is aborting.")
         print(err)
-        return
+        return None
 
-    # Isotp parameters
-    isotp_params = {
-        # Will request the sender to wait 0ms between consecutive frame.
-        # 0-127ms or 100-900ns with values from 0xF1-0xF9.
-        'stmin': 0,
-        # Request the sender to send all consecutives frames
-        # without waiting a new flow control message.
-        'blocksize': 0,
-        # Number of wait frame allowed before triggering an error.
-        'wftmax': 0,
-        # Link layer (CAN layer) works with 8 byte payload (CAN 2.0).
-        'tx_data_length': 8,
-        # Minimum length of CAN messages. Messages are padded to meet this length.
-        'tx_data_min_length': 8,
-        # Will pad all transmitted CAN messages with byte 0x00.
-        'tx_padding': 0,
-        # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds.
-        'rx_flowcontrol_timeout': 1000,
-        # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds.
-        'rx_consecutive_frame_timeout': 1000,
-        # When sending, respect the stmin requirement of the receiver.
-        # Could be set to a float value in seconds.
-        'override_receiver_stmin': None,
-        # Limit the size of receive frame.
-        'max_frame_size': 4095,
-        # Does not set the can_fd flag on the output CAN messages.
-        'can_fd': False,
-        # Does not set the bitrate_switch flag on the output CAN messages.
-        'bitrate_switch': False,
-        # Disable the rate limiter.
-        'rate_limit_enable': False,
-        # Ignored when rate_limit_enable=False. Sets the max bitrate when rate_limit_enable=True.
-        'rate_limit_max_bitrate': 1000000,
-        # Ignored when rate_limit_enable=False.
-        # Sets the averaging window size for bitrate calculation when rate_limit_enable=True.
-        'rate_limit_window_size': 0.2,
-        # Does not use the listen_mode which prevent transmission.
-        'listen_mode': False,
-    }
 
-    if args.verbose:
-        # Setup a debug listener that print all messages
-        notifier = can.Notifier(bus, [can.Printer()])
-    else:
-        notifier = can.Notifier(bus, [])
-
+def _create_isotp_addresses(args):
+    """Return (rx_addr, tx_addr) based on the id_type argument."""
     if args.id_type == "11func":
         rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x700, rxid=0x7DF)
         tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7FF, rxid=0x7F7)
@@ -203,14 +195,21 @@ def main():
         rx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)
         tx_addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=0x7F9, rxid=0x7F1)
     else:  # 29bits (default)
-        rx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0xFF)
-        tx_addr = isotp.Address(isotp.AddressingMode.NormalFixed_29bits, target_address=0xF1, source_address=0x77)
+        rx_addr = isotp.Address(
+            isotp.AddressingMode.NormalFixed_29bits,
+            target_address=0xF1,
+            source_address=0xFF,
+        )
+        tx_addr = isotp.Address(
+            isotp.AddressingMode.NormalFixed_29bits,
+            target_address=0xF1,
+            source_address=0x77,
+        )
+    return rx_addr, tx_addr
 
-    # Network/Transport layer (IsoTP protocol). Register a new listener
-    rx_stack = isotp.NotifierBasedCanStack(bus=bus, notifier=notifier, address=rx_addr, params=isotp_params)
-    tx_stack = isotp.NotifierBasedCanStack(bus=bus, notifier=notifier, address=tx_addr, params=isotp_params)
 
-    # Fixed-seed RNG so random data is reproducible and differs per DID
+def _create_responses(args):
+    """Return a response context dict for DID handling."""
     rng = random.Random(42)
     data_records = {}
     for i in range(0xfa13, 0xfa16):
@@ -225,48 +224,103 @@ def main():
     responses = {}
     for i in range(0xfa13, 0xfa16):
         requests[i] = ReadDataByIdentifier.make_request(didlist=[i], didconfig={'default': 's'})
-        responses[i] = Response(service=ReadDataByIdentifier, code=Response.Code.PositiveResponse, data=bytes([(i>>8)&0xFF,i&0xFF])+data_records[i])
-    pend_response = Response(service=ReadDataByIdentifier, code=Response.Code.RequestCorrectlyReceived_ResponsePending)
-    nega_response = Response(service=ReadDataByIdentifier, code=Response.Code.RequestOutOfRange)
+        did_bytes = bytes([(i >> 8) & 0xFF, i & 0xFF])
+        responses[i] = Response(
+            service=ReadDataByIdentifier,
+            code=Response.Code.PositiveResponse,
+            data=did_bytes + data_records[i],
+        )
+    pend_response = Response(
+        service=ReadDataByIdentifier,
+        code=Response.Code.RequestCorrectlyReceived_ResponsePending,
+    )
+    nega_response = Response(
+        service=ReadDataByIdentifier,
+        code=Response.Code.RequestOutOfRange,
+    )
+    return {
+        'requests': requests,
+        'pos': responses,
+        'pend': pend_response,
+        'nega': nega_response,
+    }
+
+
+def _start_background_sender(bus, args, stop_event):
+    """Start background sender daemon thread if bg_frames > 0."""
+    if args.bg_frames <= 0:
+        return
+    frames = generate_background_frames(args.bg_frames)
+    thread = threading.Thread(
+        target=background_sender,
+        args=(bus, frames, stop_event, _BG_FRAMES_CYCLE_TIME_MS / 1000),
+        daemon=True,
+    )
+    thread.start()
+
+
+def _handle_payload(payload, resp_ctx, tx_stack, args):
+    """Send the appropriate response for a received payload."""
+    if payload is None:
+        return
+    for i in range(0xfa13, 0xfa16):
+        if payload == resp_ctx['requests'][i].get_payload():
+            if args.pending:
+                tx_stack.send(resp_ctx['pend'].get_payload())
+                time.sleep(3)
+            if args.negative:
+                tx_stack.send(resp_ctx['nega'].get_payload())
+            else:
+                tx_stack.send(resp_ctx['pos'][i].get_payload())
+
+
+def main():
+    """Main process."""
+
+    # Parse command line arguments
+    argparser = get_argparser()
+    args = argparser.parse_args()
+
+    if not 0 <= args.bg_frames <= 500:
+        argparser.error("--bg-frames must be between 0 and 500")
+
+    bus = _create_bus(args)
+    if bus is None:
+        return
+
+    if args.verbose:
+        notifier = can.Notifier(bus, [can.Printer()])
+    else:
+        notifier = can.Notifier(bus, [])
+
+    rx_addr, tx_addr = _create_isotp_addresses(args)
+
+    rx_stack = isotp.NotifierBasedCanStack(
+        bus=bus, notifier=notifier, address=rx_addr, params=_ISOTP_PARAMS
+    )
+    tx_stack = isotp.NotifierBasedCanStack(
+        bus=bus, notifier=notifier, address=tx_addr, params=_ISOTP_PARAMS
+    )
+
+    resp_ctx = _create_responses(args)
 
     rx_stack.start()
     tx_stack.start()
 
     stop_event = threading.Event()
-    if args.bg_frames > 0:
-        frames = generate_background_frames(args.bg_frames)
-        bg_thread = threading.Thread(
-            target=background_sender,
-            args=(bus, frames, stop_event, _BG_FRAMES_CYCLE_TIME_MS / 1000),
-            daemon=True,
-        )
-        bg_thread.start()
+    _start_background_sender(bus, args, stop_event)
 
     try:
         while True:
             payload = rx_stack.recv(block=True, timeout=0.01)
-            for i in range(0xfa13, 0xfa16):
-                if payload is not None:
-                    if payload == requests[i].get_payload():
-                        if args.pending:
-                            tx_stack.send(pend_response.get_payload())
-                            time.sleep(3)
-
-                        if args.negative:
-                            tx_stack.send(nega_response.get_payload())
-
-                        else:
-                            tx_stack.send(responses[i].get_payload())
-
-    except Exception as err:
+            _handle_payload(payload, resp_ctx, tx_stack, args)
+    except Exception as err:  # pylint: disable=broad-exception-caught
         print(err)
-
-    stop_event.set()
-
-    rx_stack.stop()
-    tx_stack.stop()
-
-    bus.shutdown()
+    finally:
+        stop_event.set()
+        rx_stack.stop()
+        tx_stack.stop()
+        bus.shutdown()
 
 
 if __name__ == '__main__':

--- a/src/mock.py
+++ b/src/mock.py
@@ -42,6 +42,7 @@ def get_argparser():
         default=0,
         metavar="N",
         help="number of background CAN IDs to send at 100ms cycle (0-500, default 0)"
+    )
     parser.add_argument(
         "-i", "--id-type",
         choices=["11func", "11phys", "29bits"],
@@ -80,12 +81,12 @@ def generate_background_frames(count):
 
     frames = []
     for _ in range(n_std):
-        arb_id = rng.randint(0, 0x7FF)
+        arb_id = rng.randint(0, 0x6FF)
         data = bytes(rng.randint(0, 255) for _ in range(8))
         frames.append((arb_id, False, data))
 
     for _ in range(n_ext):
-        arb_id = rng.randint(0, 0x1FFFFFFF)
+        arb_id = rng.randint(0, 0x17FFFFFF)
         data = bytes(rng.randint(0, 255) for _ in range(8))
         frames.append((arb_id, True, data))
 


### PR DESCRIPTION
Add a CLI option to send background CAN frames with a constant 100ms interval, pseudorandom IDs, and pseudorandom data.

**Changes:**
- `-b`/`--bg-frames N` argument (0–500, default 0)
- Half standard 11-bit, half extended 29-bit IDs
- IDs and 8-byte data generated with seeded RNG (seed=42) for reproducibility
- Daemon thread cycles all frames every 100ms, exits cleanly on shutdown

Closes #1

Generated with [Claude Code](https://claude.ai/code)